### PR TITLE
Fixed documentation inconsistency

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ if (ssl) {
 // Miner Proxy Srv
 var srv = new WebSocket.Server({
     server: web,
-    path: "/proxy",
+    path: "/",
     maxPayload: 256
 });
 srv.on('connection', (ws) => {


### PR DESCRIPTION
According to the documentation, the nginx reverse proxy should be set up under /proxy. In server.js, the WebSocket is created under /proxy, which makes it effectively available under /proxy/proxy. Nevertheless, the nginx JavaScript code is requesting a WebSocket under /proxy, since node.js sees this as /, it doesn't exist, it gives nginx a 404 Not Found and nginx gives the user a 502 Bad Gateway. The solution is to create the WebSocket under / in the nodejs code so that is now properly reachable under /proxy.